### PR TITLE
Fix compile/linker errors (editor::current_room/tileset, graphics::font)

### DIFF
--- a/Grass Editor/editor.cpp
+++ b/Grass Editor/editor.cpp
@@ -6,6 +6,9 @@
 #include "map.h"
 #include "graphics.h"
 
+map::room editor::current_room;
+int editor::current_tileset;
+
 void editor::EditorInit() {
     editor::current_room = editor::CreateEmptyRoom();
     editor::current_tileset = 0;

--- a/Grass Editor/editor.h
+++ b/Grass Editor/editor.h
@@ -7,8 +7,8 @@
 
 namespace editor
 {
-    map::room current_room;
-    int current_tileset;
+    extern map::room current_room;
+    extern int current_tileset;
     void EditorInit();
     void EditorLogic();
     void EditorRender();

--- a/Grass Editor/graphics.h
+++ b/Grass Editor/graphics.h
@@ -14,8 +14,8 @@ extern SDL_Renderer* g_renderer;
 
 namespace graphics
 {
-    //TTF_Font* font;
-    void Init()
+    extern TTF_Font* font;
+    void Init();
     SDL_Texture* LoadImage(const char* path);
     void DrawImage(SDL_Texture* image, int x, int y);
     void DrawImagePart(SDL_Texture* image, int x, int y, int x2, int y2, int w, int h);


### PR DESCRIPTION
This fixes a few errors:
 - `editor::current_room` and `editor::current_tileset` should be externed in `editor.h`, otherwise this causes the linker to complain that they are being redefined multiple times.
 - Furthermore, they need to actually be declared in `editor.cpp`, otherwise the compiler will complain that they don't actually exist.
 - In `graphics.h`, `graphics::font` needs to be (1) declared, so the compiler doesn't complain that "`font` is not a member of `graphics`" and (2) externed, so the linker doesn't complain it's being redefined multiple times.
 - There was a missing semicolon after `void Init()` in `graphics.h`, which was a syntax error.

By the way, for anyone else attempting to compile the code, I used the command
```
g++ -I/usr/include/SDL2 -lSDL2 -lSDL2_ttf -lSDL2_image *.cpp -o Grass-Editor
```
to compile it. In particular, you have to use `g++` instead of `gcc` otherwise the linker will complain about C++ STL stuff being non-existent. You need SDL2, SDL2_image, and SDL2_ttf (all of which are three separate packages).